### PR TITLE
Add device performance prediction example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pt
+data/sample_performance.csv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# GPTDeepLearningTry
+# Device Performance Prediction
+
+This project demonstrates a simple deep learning workflow for predicting a device's overall performance based on benchmark scores.
+
+## Contents
+- `data/generate_data.py`: script to generate a synthetic dataset of benchmark scores.
+- `train.py`: trains a neural network model using the data.
+- `predict.py`: loads the model to predict performance for new devices and flags anomalous inputs.
+
+## Usage
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Generate sample data:
+   ```bash
+   python data/generate_data.py
+   ```
+3. Train the model:
+   ```bash
+   python train.py
+   ```
+4. Predict on new data:
+   ```bash
+   python predict.py path/to/your.csv
+   ```

--- a/data/generate_data.py
+++ b/data/generate_data.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+
+np.random.seed(0)
+
+# Generate random benchmark scores
+n_samples = 500
+cpu = np.random.normal(loc=2500, scale=300, size=n_samples)
+memory = np.random.normal(loc=1500, scale=200, size=n_samples)
+disk = np.random.normal(loc=500, scale=50, size=n_samples)
+network = np.random.normal(loc=1000, scale=150, size=n_samples)
+
+# Overall performance is a weighted combination plus noise
+performance = 0.4 * cpu + 0.3 * memory + 0.2 * disk + 0.1 * network
+performance += np.random.normal(scale=100, size=n_samples)
+
+# Create DataFrame
+df = pd.DataFrame({
+    'cpu_score': cpu,
+    'memory_score': memory,
+    'disk_score': disk,
+    'network_score': network,
+    'performance_score': performance
+})
+
+# Save to CSV
+if __name__ == '__main__':
+    df.to_csv('data/sample_performance.csv', index=False)

--- a/model.py
+++ b/model.py
@@ -1,0 +1,17 @@
+import torch
+from torch import nn
+
+class PerformancePredictor(nn.Module):
+    """Simple feed-forward network to predict device performance."""
+    def __init__(self, input_dim: int = 4, hidden_dim: int = 32):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(1)

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,37 @@
+import argparse
+import pandas as pd
+import torch
+from model import PerformancePredictor
+
+MODEL_PATH = 'model.pt'
+STATS_PATH = 'stats.pt'
+
+def load_stats():
+    data = torch.load(STATS_PATH, weights_only=False)
+    return data['mean'], data['std']
+
+def check_anomaly(features, mean, std, threshold=3.0):
+    z = torch.abs((features - mean) / std)
+    return torch.any(z > threshold, dim=1)
+
+def predict(csv_path: str):
+    df = pd.read_csv(csv_path)
+    feats = df[['cpu_score', 'memory_score', 'disk_score', 'network_score']].values
+    mean, std = load_stats()
+    norm_feats = (feats - mean) / std
+    x = torch.tensor(norm_feats, dtype=torch.float32)
+    model = PerformancePredictor()
+    model.load_state_dict(torch.load(MODEL_PATH))
+    model.eval()
+    with torch.no_grad():
+        preds = model(x).numpy()
+    anomalies = check_anomaly(torch.tensor(feats, dtype=torch.float32), mean, std)
+    df['predicted_performance'] = preds
+    df['anomaly'] = anomalies.numpy()
+    print(df)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Predict device performance')
+    parser.add_argument('csv', help='CSV file with benchmark scores')
+    args = parser.parse_args()
+    predict(args.csv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+numpy
+torch

--- a/train.py
+++ b/train.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from model import PerformancePredictor
+
+DATA_PATH = 'data/sample_performance.csv'
+MODEL_PATH = 'model.pt'
+STATS_PATH = 'stats.pt'
+
+def load_data(path=DATA_PATH):
+    df = pd.read_csv(path)
+    features = df[['cpu_score', 'memory_score', 'disk_score', 'network_score']].values
+    target = df['performance_score'].values
+    # Normalize features
+    mean = features.mean(axis=0)
+    std = features.std(axis=0)
+    normalized = (features - mean) / std
+    return torch.tensor(normalized, dtype=torch.float32), torch.tensor(target, dtype=torch.float32), mean, std
+
+def train():
+    X, y, mean, std = load_data()
+    dataset = TensorDataset(X, y)
+    loader = DataLoader(dataset, batch_size=32, shuffle=True)
+
+    model = PerformancePredictor()
+    criterion = torch.nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    for epoch in range(20):
+        for batch_x, batch_y in loader:
+            optimizer.zero_grad()
+            pred = model(batch_x)
+            loss = criterion(pred, batch_y)
+            loss.backward()
+            optimizer.step()
+        print(f'Epoch {epoch+1}: loss={loss.item():.4f}')
+
+    torch.save(model.state_dict(), MODEL_PATH)
+    torch.save({'mean': mean, 'std': std}, STATS_PATH)
+    print('Model saved to', MODEL_PATH)
+
+if __name__ == '__main__':
+    train()


### PR DESCRIPTION
## Summary
- add script to generate synthetic benchmark data
- train simple PyTorch model to predict device performance
- add prediction script for performance and anomaly detection
- document usage in README
- ignore artifacts with .gitignore

## Testing
- `pip install pandas torch --no-cache-dir`
- `python3 train.py | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_684a60c0677083249bb466c01bc62466